### PR TITLE
Add explicit <iostream> includes, fixes build with Boost 1.56

### DIFF
--- a/src/cc/error.h
+++ b/src/cc/error.h
@@ -28,6 +28,7 @@
 #include <boost/exception/get_error_info.hpp>
 #include <boost/exception/errinfo_errno.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <iostream>
 #include <cerrno>
 
 namespace cc

--- a/src/cc/input.h
+++ b/src/cc/input.h
@@ -23,6 +23,7 @@
 
 #include <ccinternal>
 
+#include <iostream>
 #include <istream>
 #include <sstream>
 

--- a/src/cc/log.h
+++ b/src/cc/log.h
@@ -25,6 +25,7 @@
 
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/filesystem.hpp>
+#include <iostream>
 #include <fstream>
 
 #include <ccerror>

--- a/src/cc/options.h
+++ b/src/cc/options.h
@@ -37,6 +37,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
+#include <iostream>
 #include <fstream>
 
 #include <ccerror>

--- a/src/cc/sig.h
+++ b/src/cc/sig.h
@@ -26,6 +26,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <iostream>
 #include <csignal>
 #include <cstdio>
 


### PR DESCRIPTION
See https://bugs.gentoo.org/show_bug.cgi?id=527658 and
https://bugs.gentoo.org/show_bug.cgi?id=533506
